### PR TITLE
Updated kill/killport

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "clean": "rm -rf ./node_modules && npm cache clean",
     "cleaninstall": "npm run clean && npm install",
     "deploy": "npm run cleaninstall && npm run build && npm run touch && npm run background",
-    "kill": "kill $(ps | awk '/aggroServer/ && !/awk/ {print $1}')",
-    "killport": "kill $(lsof -i :9876 | awk '/LISTEN/ {print $2}')",
+    "kill": "kill $(ps | awk '/aggroServer/ && !/awk/ {print $1}') || true",
+    "killport": "kill $(lsof -i :9876 | awk '/LISTEN/ {print $2}') || true",
     "start": "node aggroServer.js",
     "touch": "touch srvOut.txt srvErr.txt srvIn.txt",
     "watch": "nodemon aggroServer.js"


### PR DESCRIPTION
Updated kill and killport scripts to supress error
messages from npm in the event that there is no running
process currently on the selected port